### PR TITLE
Сброс sonar.branch.name

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -15,13 +15,15 @@ if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then
         -Dsonar.github.repository=$TRAVIS_REPO_SLUG \
         -Dsonar.github.oauth=$SONAR_GITHUB_TOKEN \
         -Dsonar.login=$SONAR_TOKEN \
-        -Dsonar.scanner.skip=false
+        -Dsonar.scanner.skip=false \
+        -Dsonar.branch.name=
 
   elif [ "$TRAVIS_BRANCH" == "develop" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     sonar-scanner \
         -Dsonar.host.url=http://sonar.silverbulleters.org \
         -Dsonar.login=$SONAR_TOKEN \
         -Dsonar.projectVersion=$version\
-        -Dsonar.scanner.skip=false
+        -Dsonar.scanner.skip=false \
+        -Dsonar.branch.name=
   fi
 fi


### PR DESCRIPTION
Убираем ошибку "To use the property "sonar.branch.name", the branch plugin is required but not installed."